### PR TITLE
path of vendor autoload.php is wrong on mod_form and view

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -28,7 +28,7 @@ defined('MOODLE_INTERNAL') || die;
 require_once ($CFG->dirroot.'/course/moodleform_mod.php');
 require_once($CFG->dirroot.'/mod/url/locallib.php');
 require_once($CFG->dirroot.'/mod/teams/lib.php');
-require_once($CFG->dirroot.'/vendor/autoload.php');
+require_once($CFG->dirroot.'/mod/teams/vendor/autoload.php');
 
 class mod_teams_mod_form extends moodleform_mod
 {

--- a/view.php
+++ b/view.php
@@ -26,7 +26,7 @@ require_once('../../config.php');
 require_once("lib.php");
 require_once("$CFG->dirroot/mod/url/locallib.php");
 require_once($CFG->libdir . '/completionlib.php');
-require_once($CFG->dirroot.'/vendor/autoload.php');
+require_once($CFG->dirroot.'/mod/teams/vendor/autoload.php');
 
 $id = required_param('id', PARAM_INT); // Course Module ID
 $u = optional_param('u', 0, PARAM_INT); // URL instance id


### PR DESCRIPTION
Thanks for this great and needed plugin.
the vendor/autoload.php file is inside the teams mod directory - fixed the include.

Merci bien,
--Yedidia